### PR TITLE
Base code for the endpoint repsonse documentation

### DIFF
--- a/orchestration/api/api_clip.py
+++ b/orchestration/api/api_clip.py
@@ -1,6 +1,6 @@
-from fastapi import Request, APIRouter, HTTPException
+from fastapi import Request, APIRouter, HTTPException, Response
 import requests
-from .api_utils import PrettyJSONResponse, ApiResponseHandler, ErrorCode
+from .api_utils import PrettyJSONResponse, ApiResponseHandler, ErrorCode, StandardErrorResponse, StandardSuccessResponse
 from orchestration.api.mongo_schemas import  PhraseModel
 from typing import Optional
 from typing import List
@@ -8,6 +8,7 @@ import json
 from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from fastapi_cache.decorator import cache
+from pydantic import BaseModel
 
 CLIP_SERVER_ADDRESS = 'http://192.168.3.31:8002'
 #CLIP_SERVER_ADDRESS = 'http://127.0.0.1:8002'
@@ -97,8 +98,16 @@ def add_phrase(request: Request,
 
     return http_clip_server_add_phrase(phrase)
 
-@router.post("/clip/phrases", response_class=PrettyJSONResponse, description="Adds a phrase to the clip server", tags=["clip"])
-def add_phrase(request: Request, phrase_data: PhraseModel):
+class AddClipPhraseResponse(BaseModel):
+    clip_vector: str
+
+@router.post("/clip/phrases",
+             description="Adds a phrase to the clip server.",
+             tags=["clip"],
+             response_model=StandardSuccessResponse[AddClipPhraseResponse],
+             status_code=201,
+             responses=ApiResponseHandler.listErrors([400, 500, 503]))
+def add_phrase(request: Request, response: Response, phrase_data: PhraseModel):
     response_handler = ApiResponseHandler(request)
 
     try:

--- a/orchestration/api/api_utils.py
+++ b/orchestration/api/api_utils.py
@@ -6,6 +6,8 @@ from fastapi.responses import JSONResponse
 from enum import Enum
 import time
 from fastapi import Request
+from typing import TypeVar, Generic
+from pydantic import BaseModel
 
 
 class PrettyJSONResponse(Response):
@@ -25,6 +27,18 @@ class ErrorCode(Enum):
     ELEMENT_NOT_FOUND = 2
     INVALID_PARAMS = 3
 
+T = TypeVar('T')
+class StandardSuccessResponse(BaseModel, Generic[T]):
+    url: str
+    duration: int
+    response: T
+
+class StandardErrorResponse(BaseModel):
+    url: str
+    duration: int
+    errorCode: int
+    errorString: str
+
 class ApiResponseHandler:
     def __init__(self, request: Request):
         self.url = str(request.url)
@@ -32,6 +46,13 @@ class ApiResponseHandler:
 
     def _elapsed_time(self) -> float:
         return time.time() - self.start_time
+    
+    @staticmethod
+    def listErrors(errors: list[int]) -> dict:
+        repsonse = {}
+        for err in errors:
+            repsonse[err] = {"model": StandardErrorResponse}
+        return repsonse
 
     def create_success_response(self, response_data: dict, http_status_code: int, headers: dict = {"Cache-Control": "no-store"}):
         # Validate the provided HTTP status code


### PR DESCRIPTION
This PR has base code for documenting the response of one endpoint. With this code, the documentation shows this:

![doc](https://github.com/kk-digital/kcg-ml-image-pipeline/assets/34079003/7c7110b4-6114-483e-936c-9b82acd25cf8)

This is an example, so maybe @sandrodevdariani will want to adapt it to the current code style or event create a new PR. As an example of a potential problem, I think the structure of the `AddClipPhraseResponse` class is incorrect, as I did not check how the real response of the CLIP server is.