### PR TITLE
Changes for generic API procedures

### DIFF
--- a/orchestration/api/api_tag.py
+++ b/orchestration/api/api_tag.py
@@ -1295,8 +1295,8 @@ def get_tagged_images(
             description="Get all tagged images",
             response_model=StandardSuccessResponseV1[ListImageTag], 
             responses=ApiResponseHandlerV1.listErrors([400, 422, 500]))
-def get_all_tagged_images(request: Request):
-    response_handler = ApiResponseHandlerV1(request)
+async def get_all_tagged_images(request: Request):
+    response_handler = await ApiResponseHandlerV1.createInstance(request)
 
     try:
         # Execute the query to get all tagged images
@@ -1336,9 +1336,9 @@ def get_all_tagged_images(request: Request):
              description="Add Tag Category",
              response_model=StandardSuccessResponseV1[TagCategory],
              responses=ApiResponseHandlerV1.listErrors([422, 500]))
-def add_new_tag_category(request: Request, tag_category_data: NewTagCategory):
-    tag_category_dict = jsonable_encoder(tag_category_data) 
-    response_handler = ApiResponseHandlerV1(request, body_data=tag_category_dict)
+async def add_new_tag_category(request: Request, tag_category_data: NewTagCategory):
+    response_handler = await ApiResponseHandlerV1.createInstance(request)
+
     try:
         # Assign new tag_category_id
         last_entry = request.app.tag_categories_collection.find_one({}, sort=[("tag_category_id", -1)])
@@ -1440,14 +1440,12 @@ def get_image_count_by_tag(
               description="Update tag category",
               response_model=StandardSuccessResponseV1[TagCategory],
               responses=ApiResponseHandlerV1.listErrors([400, 404, 422, 500]))
-def update_tag_category_v1(
+async def update_tag_category_v1(
     request: Request, 
     tag_category_id: int,
     update_data: NewTagCategory
 ):
-    
-    update_data_dict = jsonable_encoder(update_data)
-    response_handler = ApiResponseHandlerV1(request, body_data=update_data_dict)
+    response_handler = await ApiResponseHandlerV1.createInstance(request)
 
     query = {"tag_category_id": tag_category_id}
     existing_category = request.app.tag_categories_collection.find_one(query)

--- a/orchestration/api/api_utils.py
+++ b/orchestration/api/api_utils.py
@@ -231,6 +231,23 @@ class ApiResponseHandlerV1:
             "query": dict(request.query_params)  # Extracted from request
         }
 
+    @staticmethod
+    async def createInstance(request: Request):
+        body = await request.body()
+        body_dictionary = {}
+        if (len(body) > 0):
+            body_string = body.decode('utf-8')
+            body_dictionary = json.loads(body_string)
+
+        instance = ApiResponseHandlerV1(request, body_dictionary)
+        return instance
+    
+    # In middlewares, this must be called instead of "createInstance", as "createInstance" may hang trying to get the request body.
+    @staticmethod
+    def createInstanceWithBody(request: Request, body_data: Dict[str, Any]):
+        instance = ApiResponseHandlerV1(request, body_data)
+        return instance
+
     
     def _elapsed_time(self) -> float:
         return datetime.now() - self.start_time


### PR DESCRIPTION
- A new static method for creating ApiResponseHandlerV1 instances, that automatically retrieves the request body, was created. It should allow to replace all the current constructors and remove the code for passing body to them, which has a very high risk of introducing error when copying ans pasting the code.
- There is also a new static method for creating ApiResponseHandlerV1 instances, that was created only as a helper for validation_exception_handler. The idea is to have it if the current constructor is removed.
- Now validation_exception_handler gets the body of the request and includes it as part of the standard error response, as expected.
- Now validation_exception_handler is also including human readable text about the validation problems.