### PR TITLE
Create ingress-video endpoint & update external-images for sequential id & Add tagging api for extracts

### DIFF
--- a/orchestration/api/api_external_images.py
+++ b/orchestration/api/api_external_images.py
@@ -86,7 +86,7 @@ async def add_external_image_data(request: Request, image_data: ExternalImageDat
             tags=["external-images"],  
             response_model=StandardSuccessResponseV1[ListExternalImageData],  
             responses=ApiResponseHandlerV1.listErrors([422, 500]))
-async def add_external_image_data_list(request: Request, image_data_list: List[ExternalImageData]):
+async def add_external_image_data_list(request: Request, image_data_list: List[ExternalImageDataV1]):
     api_response_handler = await ApiResponseHandlerV1.createInstance(request)
     updaded_image_data_list = []
     try:

--- a/orchestration/api/api_external_images.py
+++ b/orchestration/api/api_external_images.py
@@ -25,16 +25,6 @@ async def add_external_image_data(request: Request, image_data: ExternalImageDat
 
 
     try:
-
-        objects = cmd.get_list_of_objects(request.app.minio_client, "datasets")
-        dataset_path = f'{image_data.dataset}'
-        
-        if dataset_path not in objects:
-            return api_response_handler.create_error_response_v1(
-                error_code=ErrorCode.INVALID_PARAMS,
-                error_string=f"Dataset '{image_data.dataset}' does not exist.",
-                http_status_code=422,
-            )
     
         # Check if the image data already exists
         existed = request.app.external_images_collection.find_one({

--- a/orchestration/api/api_external_images.py
+++ b/orchestration/api/api_external_images.py
@@ -70,9 +70,9 @@ async def add_external_image_data_list(request: Request, image_data_list: List[E
                 "image_hash": image_data.image_hash
             })
 
-            uuid = str(uuid.uuid4())  # Generate a new UUID for new entries
+            image_uuid = str(uuid.uuid4())  # Generate a new UUID for new entries
             if existed is None:
-                image_data.uuid = uuid
+                image_data.uuid = image_uuid
                 image_data.upload_date = str(datetime.now())
                 request.app.external_images_collection.insert_one(image_data.to_dict())
             else:
@@ -87,7 +87,7 @@ async def add_external_image_data_list(request: Request, image_data_list: List[E
                         "file_path": image_data.file_path,
                         "source_image_dict": image_data.source_image_dict,
                         "task_attributes_dict": image_data.task_attributes_dict,
-                        "uuid": uuid
+                        "uuid": image_uuid
                     }
                 })
 
@@ -97,6 +97,7 @@ async def add_external_image_data_list(request: Request, image_data_list: List[E
         )
     
     except Exception as e:
+        print(e)
         return api_response_handler.create_error_response_v1(
             error_code=ErrorCode.OTHER_ERROR, 
             error_string=str(e),
@@ -154,7 +155,7 @@ async def get_external_image_data_list(request: Request, body: ListImageHashRequ
 
         return api_response_handler.create_success_response_v1(
             response_data={"data": list_external_images},
-            http_status_code=200  
+            http_status_code=200
         )
     
     except Exception as e:

--- a/orchestration/api/api_external_images.py
+++ b/orchestration/api/api_external_images.py
@@ -70,9 +70,10 @@ async def add_external_image_data_list(request: Request, image_data_list: List[E
                 "image_hash": image_data.image_hash
             })
 
+            uuid = str(uuid.uuid4())  # Generate a new UUID for new entries
             if existed is None:
+                image_data.uuid = uuid
                 image_data.upload_date = str(datetime.now())
-                uuid = str(uuid.uuid4())  # Generate a new UUID for new entries
                 request.app.external_images_collection.insert_one(image_data.to_dict())
             else:
                 request.app.external_images_collection.update_one({

--- a/orchestration/api/api_ingress_videos.py
+++ b/orchestration/api/api_ingress_videos.py
@@ -31,7 +31,7 @@ def minio_path_with_seq_id(dataset_name, middle_path, seq_id):
 
 def get_minio_video_path(seq_id, dataset_name, format):
 
-    folder_id = (seq_id // 1000)
+    folder_id = (seq_id // 1000) + 1
     file_id = (seq_id % 1000)
     
     folder_name = f"{folder_id:04d}"

--- a/orchestration/api/api_ingress_videos.py
+++ b/orchestration/api/api_ingress_videos.py
@@ -1,0 +1,310 @@
+from fastapi import APIRouter, Request
+from .api_utils import ApiResponseHandlerV1, \
+    StandardSuccessResponseV1, ErrorCode, WasPresentResponse, DeletedCount
+
+# import schema
+from .mongo_schemas import VideoMetaData, ListVideoMetaData
+
+# import time library
+from datetime import datetime
+
+# import typing
+from typing import List
+
+router = APIRouter()
+
+api_prefix = '/ingress-video'
+
+def minio_path_with_seq_id(dataset_name, middle_path, seq_id):
+    folder_id = (seq_id // 1000) + 1
+    file_id = (file_id % 1000) + 1
+    
+    folder_name = f"{folder_id:04d}"
+    file_name = f"{file_id:06d}"
+    
+    if middle_path != '' and middle_path is not None:
+        path = f'{dataset_name}/{middle_path}/{folder_name}/{file_name}'
+    else:
+        path = f'{dataset_name}/{folder_name}/{file_name}'
+    
+    return path
+
+def get_minio_video_path(seq_id, dataset_name, format):
+
+    folder_id = (seq_id // 1000)
+    file_id = (seq_id % 1000)
+    
+    folder_name = f"{folder_id:04d}"
+    file_name = f"{file_id:06d}"
+
+    path = f'{dataset_name}/{folder_name}/{file_name}'
+
+    return f'{path}.{format}'
+
+def get_next_seq_id(request: Request):
+    # get ingress video counter
+    counter = request.app.counters_collection.find_one({"_id": "ingress_video"})
+    # create counter if it doesn't exist already
+    if counter is None:
+        request.app.counters_collection.insert_one({"_id": "ingress_video", "seq":0})
+    counter_seq = counter["seq"] if counter else 0 
+    counter_seq += 1
+    
+    return counter_seq
+
+def update_seq_id(request: Request, seq_id = 0):
+
+    try:
+        ret = request.app.counters_collection.update_one(
+            {"_id": "ingress_video"},
+            {"$set": {"seq": seq_id}})
+    except Exception as e:
+        raise Exception("Updating of classifier counter failed: {}".format(e))
+    
+
+@router.post(f'{api_prefix}/add-video',
+             description='Add video for extracting external images',
+             response_model=StandardSuccessResponseV1[VideoMetaData],
+             responses=ApiResponseHandlerV1.listErrors([404, 422, 500]))
+async def add_video(request: Request, video_meta_data: VideoMetaData):
+    # TODO: add minio path into video meta data:
+    # for this, need to add dataset name
+    api_response_handler = await ApiResponseHandlerV1.createInstance(request)
+
+
+    
+    try:
+        # check if video already exists
+        video_file_hash = video_meta_data.file_hash
+        existed = request.app.ingress_video_collection.find_one({
+            'file_hash': video_file_hash
+        })
+
+        video_meta_data.upload_date = str(datetime.now())
+        if existed is None:
+            # TODO: add dataset so get sequential id for specific dataset
+            next_seq_id = get_next_seq_id(request)
+            video_meta_data.file_path = get_minio_video_path(next_seq_id,
+                                                            video_meta_data.dataset, 
+                                                            video_meta_data.file_type)
+
+            request.app.ingress_video_collection.insert_one(video_meta_data.to_dict())
+            update_seq_id(request=request, seq_id=next_seq_id)
+
+        else:
+            video_meta_data.file_path = existed['file_path']
+            request.app.ingress_video_collection.update_one({
+                'file_hash': video_file_hash
+            }, {
+                '$set': video_meta_data.to_dict()
+            })
+
+
+        return api_response_handler.create_success_response_v1(
+            response_data=video_meta_data.to_dict(),
+            http_status_code=200
+        )
+    except Exception as e:
+        return api_response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR,
+            error_string=str(e),
+            http_status_code=500
+        )
+    
+@router.post(f'{api_prefix}/add-video-list',
+             description='Add video for extracting external image list',
+             response_model=StandardSuccessResponseV1[ListVideoMetaData],
+             responses=ApiResponseHandlerV1.listErrors([404, 422, 500]))
+async def add_video_list(request: Request, video_meta_data_list: List[VideoMetaData]):
+    api_response_handler = await ApiResponseHandlerV1.createInstance(request)
+
+    try:
+
+        for video_meta_data in video_meta_data_list:
+            # add minio video path
+            
+            # check if video already exists
+            video_file_hash = video_meta_data.file_hash
+            existed = request.app.ingress_video_collection.find_one({
+                'file_hash': video_file_hash
+            })
+
+            video_meta_data.upload_date = str(datetime.now())
+            if existed is None:
+                next_seq_id = get_next_seq_id(request)
+                video_meta_data.file_path = get_minio_video_path(next_seq_id, 
+                                                        video_meta_data.dataset, 
+                                                        video_meta_data.file_type)
+                request.app.ingress_video_collection.insert_one(video_meta_data.to_dict())
+                update_seq_id(next_seq_id)
+
+            else:
+                video_meta_data.file_path = existed['file_path']
+                request.app.ingress_video_collection.update_one({
+                    'file_hash': video_file_hash
+                }, {
+                    '$set': video_meta_data.to_dict()
+                })
+
+        return api_response_handler.create_success_response_v1(
+            response_data={'data': [video_meta_data.to_dict() \
+                                    for video_meta_data in video_meta_data_list]},
+            http_status_code=200
+        )
+    except Exception as e:
+        return api_response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR,
+            error_string=str(e),
+            http_status_code=500
+        )
+
+
+@router.get(f'{api_prefix}/get-video',
+            description='Get video data by video hash',
+            response_model=StandardSuccessResponseV1[VideoMetaData],
+            responses=ApiResponseHandlerV1.listErrors([404, 422, 500]))
+async def get_video_list(request: Request, video_hash: str):
+    api_response_handler = await ApiResponseHandlerV1.createInstance(request)
+
+    try:
+        video_data = request.app.ingress_video_collection.find_one({
+            'file_hash': video_hash
+        })
+
+        video_data.pop('_id')
+        video_data = dict(video_data)
+
+        return api_response_handler.create_success_response_v1(
+            response_data=video_data,
+            http_status_code=200
+        )
+    except Exception as e:
+        return api_response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR,
+            error_string=str(e),
+            http_status_code=500
+        )
+
+
+@router.get(f'{api_prefix}/get-video-list',
+            description='Get list of video by video hash list',
+            response_model=StandardSuccessResponseV1[ListVideoMetaData],
+            responses=ApiResponseHandlerV1.listErrors([404, 422, 500]))
+async def get_video_list(request: Request, video_hash_list: List[str]):
+    api_response_handler = await ApiResponseHandlerV1.createInstance(request)
+
+    try:
+        pipeline = [
+            {
+                '$match': {
+                    'file_hash': {
+                        '$in': video_hash_list
+                    }
+                }
+            },
+            {
+                '$project': {
+                    '_id': 0
+                }
+            }
+        ]
+        video_list = list(request.app.ingress_video_collection.aggregate(pipeline))
+
+        return api_response_handler.create_success_response_v1(
+            response_data={'data': video_list},
+            http_status_code=200
+        )
+    except Exception as e:
+        return api_response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR,
+            error_string=str(e),
+            http_status_code=500
+        )
+    
+@router.get(f'{api_prefix}/get-all-video',
+            description='Get list of video by video hash list',
+            response_model=StandardSuccessResponseV1[ListVideoMetaData],
+            responses=ApiResponseHandlerV1.listErrors([404, 422, 500]))
+async def get_video_list(request: Request):
+    api_response_handler = await ApiResponseHandlerV1.createInstance(request)
+
+    try:
+        pipeline = [
+            {
+                '$match': {}
+            },
+            {
+                '$project': {
+                    '_id': 0
+                }
+            }
+        ]
+        video_list = list(request.app.ingress_video_collection.aggregate(pipeline))
+
+        return api_response_handler.create_success_response_v1(
+            response_data={'data': video_list},
+            http_status_code=200
+        )
+    except Exception as e:
+        return api_response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR,
+            error_string=str(e),
+            http_status_code=500
+        )
+
+@router.delete(f'{api_prefix}/delete-video',
+               description='Delete ingress video',
+               response_model=StandardSuccessResponseV1[WasPresentResponse],
+               responses=ApiResponseHandlerV1.listErrors([404, 422, 500]))
+async def delete_video(request: Request, video_hash: str):
+    api_response_handler = await ApiResponseHandlerV1.createInstance(request)
+
+    try:
+        result = request.app.ingress_video_collection.delete_one({
+            'file_hash': video_hash
+        })
+
+        if result.deleted_count == 0:
+            return api_response_handler.create_success_delete_response_v1(
+                wasPresent=False,
+                http_status_code=404
+            )
+        
+        return api_response_handler.create_success_delete_response_v1(
+            wasPresent=True,
+            http_status_code=200
+        )
+    except Exception as e:
+        return api_response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR,
+            error_string=str(e),
+            http_status_code=500
+        )
+    
+@router.delete(f'{api_prefix}/delete-video-list',
+               description='Delete ingress video list',
+               response_model=StandardSuccessResponseV1[DeletedCount],
+               responses=ApiResponseHandlerV1.listErrors([404, 422, 500]))
+async def delete_video_list(request: Request, video_hash_list: List[str]):
+    api_response_handler = await ApiResponseHandlerV1.createInstance(request)
+
+    try:
+        deleted_count = 0
+        for video_hash in video_hash_list:
+            result = request.app.ingress_video_collection.delete_one({
+                'file_hash': video_hash
+            })
+
+            if result.deleted_count != 0:
+                deleted_count += 1
+
+        return api_response_handler.create_success_response_v1(
+            response_data={'deleted_count': deleted_count},
+            http_status_code=200
+        )
+    except Exception as e:
+        return api_response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR,
+            error_string=str(e),
+            http_status_code=500
+        )

--- a/orchestration/api/api_ingress_videos.py
+++ b/orchestration/api/api_ingress_videos.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 # import typing
 from typing import List
-from api_utils import get_next_seq_id, update_seq_id, get_minio_file_path
+from .api_utils import get_next_seq_id, update_seq_id, get_minio_file_path
 
 router = APIRouter()
 

--- a/orchestration/api/api_utils.py
+++ b/orchestration/api/api_utils.py
@@ -493,3 +493,39 @@ def find_or_create_next_folder_and_index(client: Minio, bucket: str, base_folder
 
 class CountLastHour(BaseModel):
     jobs_count: dict
+
+def get_id(bucket: str, dataset: str) -> str:
+    return '{}_{}'.format(bucket, dataset)
+
+def get_minio_file_path(seq_id, dataset_name, format, sample_size = 1000):
+
+    folder_id = (seq_id // sample_size) + 1
+    file_id = (seq_id % sample_size)
+    
+    folder_name = f"{folder_id:04d}"
+    file_name = f"{file_id:06d}"
+
+    path = f'{dataset_name}/{folder_name}/{file_name}'
+
+    return f'{path}.{format}'
+
+def get_next_seq_id(request: Request, bucket: str, dataset: str):
+    # get ingress video counter
+    counter = request.app.counters_collection.find_one({"_id": '{}_{}'.format(bucket, dataset)})
+    # create counter if it doesn't exist already
+    if counter is None:
+        request.app.counters_collection.insert_one({"_id": get_id(bucket, dataset), "seq":0})
+    counter_seq = counter["seq"] if counter else 0 
+    counter_seq += 1
+    
+    return counter_seq
+
+def update_seq_id(request: Request, bucket:str, dataset: str, seq_id = 0):
+
+    try:
+        ret = request.app.counters_collection.update_one(
+            {"_id": get_id(bucket, dataset)},
+            {"$set": {"seq": seq_id}})
+    except Exception as e:
+        raise Exception("Updating of classifier counter failed: {}".format(e))
+    

--- a/orchestration/api/main.py
+++ b/orchestration/api/main.py
@@ -42,6 +42,7 @@ from orchestration.api.api_rank_active_learning_policy import router as rank_act
 from orchestration.api.api_image_hashes import router as image_hashes_router
 from orchestration.api.api_external_images import router as external_images_router
 from orchestration.api.api_extracts import router as extracts_router
+from orchestration.api.api_ingress_videos import router as ingress_videos_router
 from utility.minio import cmd
 
 config = dotenv_values("./orchestration/api/.env")
@@ -88,6 +89,7 @@ app.include_router(rank_active_learning_policy_router)
 app.include_router(image_hashes_router)
 app.include_router(external_images_router)
 app.include_router(extracts_router)
+app.include_router(ingress_videos_router)
 
 
 
@@ -232,6 +234,7 @@ def startup_db_client():
     # external image collection
     app.external_images_collection = app.mongodb_db["external_images"]
     app.extracts_collection = app.mongodb_db["extracts"]
+    app.ingress_video_collection = app.mongodb_db["ingress_videos"]
 
     pseudo_tag_uuid_index=[
     ('uuid', pymongo.ASCENDING)
@@ -446,6 +449,13 @@ def startup_db_client():
     ]
     create_index_if_not_exists(app.image_pair_ranking_collection, pair_rank_hash_index_2, 'pair_rank_hash_index_2')
 
+    # create index for ingress_video_collection
+    ingress_video_hash_index = [
+
+        ('file_hash', pymongo.ASCENDING)
+    ]
+    create_index_if_not_exists(app.ingress_video_collection, ingress_video_hash_index,
+    'ingress_video_hash_index')
 
 
     print("Connected to the MongoDB database!")

--- a/orchestration/api/mongo_schemas.py
+++ b/orchestration/api/mongo_schemas.py
@@ -658,3 +658,34 @@ class ListSimilarityScoreTask(BaseModel):
     images: List[SimilarityScoreTask]
 
 
+
+class VideoMetaData(BaseModel):
+    file_hash: str
+    filename: str
+    file_path: str
+    file_type: str
+    source_url: str
+    video_length: int
+    video_resolution: str
+    video_frame_rate: int
+    video_description: str
+    dataset: str
+    upload_date: str
+
+    def to_dict(self):
+        return {
+            "file_hash": self.file_hash,
+            "filename": self.filename,
+            "file_path": self.file_path,
+            "file_type": self.file_type,
+            "source_url": self.source_url,
+            "video_length": self.video_length,
+            "video_resolution": self.video_resolution,
+            "video_frame_rate": self.video_frame_rate,
+            "video_description": self.video_description,
+            "dataset": self.dataset,
+            "upload_date": self.upload_date
+        }
+
+class ListVideoMetaData(BaseModel):
+    data: List[VideoMetaData]

--- a/orchestration/api/mongo_schemas.py
+++ b/orchestration/api/mongo_schemas.py
@@ -374,6 +374,7 @@ class ListExtractImageData(BaseModel):
     data: List[ExtractImageData] 
 
 class ExternalImageData(BaseModel):
+    uuid: str
     image_hash: str
     dataset:str
     image_resolution: ImageResolution
@@ -385,6 +386,7 @@ class ExternalImageData(BaseModel):
 
     def to_dict(self):
         return {
+            "uuid": self.uuid,
             "dataset": self.dataset,
             "upload_date": self.upload_date,
             "image_hash": self.image_hash,

--- a/orchestration/api/mongo_schemas.py
+++ b/orchestration/api/mongo_schemas.py
@@ -374,19 +374,16 @@ class ListExtractImageData(BaseModel):
     data: List[ExtractImageData] 
 
 class ExternalImageData(BaseModel):
-    uuid: str
     image_hash: str
     dataset:str
     image_resolution: ImageResolution
     image_format: str
     file_path: str
-    upload_date: str
     source_image_dict: dict
     task_attributes_dict: dict
 
     def to_dict(self):
         return {
-            "uuid": self.uuid,
             "dataset": self.dataset,
             "upload_date": self.upload_date,
             "image_hash": self.image_hash,

--- a/orchestration/api/mongo_schemas.py
+++ b/orchestration/api/mongo_schemas.py
@@ -380,6 +380,7 @@ class ExternalImageData(BaseModel):
     image_resolution: ImageResolution
     image_format: str
     file_path: str
+    upload_date: str
     source_image_dict: dict
     task_attributes_dict: dict
 
@@ -407,6 +408,19 @@ class ExternalImageDataV1(BaseModel):
     source_image_dict: dict
     task_attributes_dict: dict
     uuid: str
+
+    def to_dict(self):
+        return {
+            "uuid": self.uuid,
+            "dataset": self.dataset,
+            "upload_date": self.upload_date,
+            "image_hash": self.image_hash,
+            "image_resolution": self.image_resolution.to_dict(),
+            "image_format": self.image_format,
+            "file_path": self.file_path,
+            "source_image_dict": self.source_image_dict,
+            "task_attributes_dict": self.task_attributes_dict,
+        }
 
 class ListExternalImageData(BaseModel):
     data: List[ExternalImageDataV1]


### PR DESCRIPTION
## Create endpoint for ingress-video

#### ingress_video_collection structure
    file_hash: str
    filename: str
    file_path: str
    file_type: str
    source_url: str
    video_length: int
    video_resolution: str
    video_frame_rate: int
    video_description: str
    dataset: str
    upload_date: str

#### Endpoint
    /ingress-video/add-video
    /ingress-video/add-video-list
    /ingress-video/get-all-video
    /ingress-video/delete-video
    /ingress-video/delete-video-list

## Update ingress-video and external-images endpoint for updating sequential id

###### For this, I used counters_collection to count the sequential id for each dataset
    _id: {bucket_name}_{dataset_name}
    seq: sequential id
    
## Add tagging api for extracts
#### Endpoint
    /extracts/add-tag-to-extract,
    /extracts/remove-tag-from-extract,
    /extracts/get-images-by-tag-id,
    /extracts/get-tag-list-for-image,
    /extracts/get-images-count-by-tag-id