### PR TITLE
Disable external images datasets validation

### DIFF
--- a/orchestration/api/api_external_images.py
+++ b/orchestration/api/api_external_images.py
@@ -23,7 +23,7 @@ async def add_external_image_data(request: Request, image_data: ExternalImageDat
 
 
     try:
-
+        '''
         objects = cmd.get_list_of_objects(request.app.minio_client, "datasets")
         dataset_path = f'{image_data.dataset}'
         
@@ -33,7 +33,7 @@ async def add_external_image_data(request: Request, image_data: ExternalImageDat
                 error_string=f"Dataset '{image_data.dataset}' does not exist.",
                 http_status_code=422,
             )
-    
+        '''
         # Check if the image data already exists
         existed = request.app.external_images_collection.find_one({
             "image_hash": image_data.image_hash


### PR DESCRIPTION
The code for validating if the dataset exists was removed from “/external-images/add-external-image”, as it is checking the folder for generated images and we don’t have yet well defined how this should work for external images.