### PR TITLE
kcg-ml-image-pipeline: update the classifier training scripts to train models for both 512*512 and separate models for all resolutions.

### DIFF
--- a/orchestration/api/api_tag.py
+++ b/orchestration/api/api_tag.py
@@ -943,7 +943,7 @@ def get_tagged_images_v2(
                     if not image:
                         continue
                     
-                    if image['task_input_dict.image_width'] == 512 and image['task_input_dict.image_height'] == 512:
+                    if image['task_input_dict']['image_width'] == 512 and image['task_input_dict']['image_height'] == 512:
                         print("512*512", image, tag_data['image_hash'])
                         temp_image_tags_cursor.append(tag_data)
                         
@@ -969,6 +969,7 @@ def get_tagged_images_v2(
 
     except Exception as e:
         # Log the exception details here, if necessary
+        print(e)
         return response_handler.create_error_response_v1(
             error_code=ErrorCode.OTHER_ERROR, error_string="Internal Server Error", http_status_code=500
         )

--- a/orchestration/api/api_tag.py
+++ b/orchestration/api/api_tag.py
@@ -893,7 +893,7 @@ def get_tagged_images_v2(
     tag_id: int,
     start_date: str = None,
     end_date: str = None,
-    image_type: str = Query('all_resolutions', description="Resolution of the images to be returned. Options: 'all_resolutions', '512*512_resolution'"),
+    image_type: str = Query('all_resolutions', description="Resolution of the images to be returned. Options: 'all_resolutions', '512*512_resolutions'"),
     order: str = Query("desc", description="Order in which the data should be returned. 'asc' for oldest first, 'desc' for newest first")
 ):
     response_handler = ApiResponseHandlerV1(request)
@@ -912,12 +912,12 @@ def get_tagged_images_v2(
         query = {"tag_id": tag_id}
         if image_type == 'all_resolutions':
             pass
-        elif image_type == '512*512_resolution':
+        elif image_type == '512*512_resolutions':
             query["image_source"] = {"$in": ["generated_image", "extract_image"]}
         else:
             return response_handler.create_error_response_v1(
                 error_code=ErrorCode.INVALID_PARAMS, 
-                error_string="Invalid resolution. Options: 'all_resolutions', '512*512_resolution", 
+                error_string="Invalid resolution. Options: 'all_resolutions', '512*512_resolutions", 
                 http_status_code=400,
             )
             
@@ -931,7 +931,7 @@ def get_tagged_images_v2(
         # Execute the query
         image_tags_cursor = list(request.app.image_tags_collection\
                                             .find(query).sort("creation_time", sort_order))
-        if image_type == '512*512_resolution':
+        if image_type == '512*512_resolutions':
             # get only image resolution 512 * 512
             temp_image_tags_cursor = []
             for tag_data in image_tags_cursor:

--- a/orchestration/api/api_tag.py
+++ b/orchestration/api/api_tag.py
@@ -5,6 +5,7 @@ from orchestration.api.mongo_schema.tag_schemas import TagDefinition, ImageTag, 
 from .mongo_schemas import Classifier
 from typing import Union
 from .api_utils import PrettyJSONResponse, validate_date_format, ApiResponseHandler, ErrorCode, StandardSuccessResponse, WasPresentResponse, TagsListResponse, VectorIndexUpdateRequest, TagsCategoryListResponse, TagResponse, TagCountResponse, StandardSuccessResponseV1, ApiResponseHandlerV1, TagIdResponse, ListImageTag, TagListForImages
+from .api_utils import build_date_query
 import traceback
 from bson import ObjectId
 from fastapi.encoders import jsonable_encoder
@@ -810,7 +811,167 @@ def get_tagged_images(
         return response_handler.create_error_response_v1(
             error_code=ErrorCode.OTHER_ERROR, error_string="Internal Server Error", http_status_code=500
         )
+        
+        
+@router.get("/tags/get-images-by-source",
+            tags=["tags"], 
+            status_code=200,
+            description="Get images by tag_id and source",
+            response_model=StandardSuccessResponseV1[ListImageTag], 
+            responses=ApiResponseHandlerV1.listErrors([400, 422, 500]))
+def get_tagged_images_v2(
+    request: Request, 
+    tag_id: int,
+    start_date: str = None,
+    end_date: str = None,
+    image_sources: List[str] = Query(None, description="List of image sources to filter by Options: 'generated_image', 'extract_image', 'external_image'"),
+    order: str = Query("desc", description="Order in which the data should be returned. 'asc' for oldest first, 'desc' for newest first")
+):
+    print(1)
+    response_handler = ApiResponseHandlerV1(request)
+    print(2)
+    try:
+        
+        # Validate start_date and end_date
+        validated_start_date = validate_date_format(start_date)
+        validated_end_date = validate_date_format(end_date)
+        if (validated_start_date is None and start_date) or (validated_end_date is None and end_date):
+            return response_handler.create_error_response_v1(
+                error_code=ErrorCode.INVALID_PARAMS, 
+                error_string="Invalid start_data and end_date format. Expected format: YYYY-MM-DDTHH:MM:SS", 
+                http_status_code=400,
+            )
+        # Build the query
+        query = {"tag_id": tag_id}
+        if image_sources:
+            query["image_source"] = {"$in": image_sources}
+        date_range_query = build_date_query(date_from=validated_start_date, 
+                                            date_to=validated_end_date)
+        query.update(date_range_query)
+        
+        # Decide the sort order
+        sort_order_mapping = {"desc": -1, "asc": 1}
+        sort_order = sort_order_mapping.get(order, 1)
+        # Execute the query
+        image_tags_cursor = request.app.image_tags_collection\
+                                            .find(query).sort("creation_time", sort_order)
+        # Process the results
+        image_info_list = []
+        for tag_data in image_tags_cursor:
+            if "image_hash" in tag_data and "user_who_created" in tag_data and "file_path" in tag_data:
+                image_tag = ImageTag(
+                    tag_id=int(tag_data["tag_id"]),
+                    file_path=tag_data["file_path"], 
+                    image_hash=str(tag_data["image_hash"]),
+                    tag_type=int(tag_data["tag_type"]),
+                    user_who_created=tag_data["user_who_created"],
+                    creation_time=tag_data.get("creation_time", None)
+                )
+                image_info_list.append(image_tag.model_dump())  # Convert to dictionary
+        # Return the list of images in a standard success response
+        return response_handler.create_success_response_v1(
+                                                           response_data={"images": image_info_list}, 
+                                                           http_status_code=200,
+                                                           )
+
+    except Exception as e:
+        print(e)
+        # Log the exception details here, if necessary
+        return response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR, error_string="Internal Server Error", http_status_code=500
+        )
     
+        
+@router.get("/tags/get-images-by-image-type",
+            tags=["tags"], 
+            status_code=200,
+            description="Get images by tag_id and resolution",
+            response_model=StandardSuccessResponseV1[ListImageTag], 
+            responses=ApiResponseHandlerV1.listErrors([400, 422, 500]))
+def get_tagged_images_v2(
+    request: Request, 
+    tag_id: int,
+    start_date: str = None,
+    end_date: str = None,
+    image_type: str = Query('all_resolutions', description="Resolution of the images to be returned. Options: 'all_resolutions', '512*512_resolution'"),
+    order: str = Query("desc", description="Order in which the data should be returned. 'asc' for oldest first, 'desc' for newest first")
+):
+    response_handler = ApiResponseHandlerV1(request)
+     
+    try:
+        # Validate start_date and end_date
+        validated_start_date = validate_date_format(start_date)
+        validated_end_date = validate_date_format(end_date)
+        if (validated_start_date is None and start_date) or (validated_end_date is None and end_date):
+            return response_handler.create_error_response_v1(
+                error_code=ErrorCode.INVALID_PARAMS, 
+                error_string="Invalid start_data and end_date format. Expected format: YYYY-MM-DDTHH:MM:SS", 
+                http_status_code=400,
+            )
+        # Build the query
+        query = {"tag_id": tag_id}
+        if image_type == 'all_resolutions':
+            pass
+        elif image_type == '512*512_resolution':
+            query["image_source"] = {"$in": ["generated_image", "extract_image"]}
+        else:
+            return response_handler.create_error_response_v1(
+                error_code=ErrorCode.INVALID_PARAMS, 
+                error_string="Invalid resolution. Options: 'all_resolutions', '512*512_resolution", 
+                http_status_code=400,
+            )
+            
+        date_range_query = build_date_query(date_from=validated_start_date, 
+                                            date_to=validated_end_date)
+        query.update(date_range_query)
+        
+        # Decide the sort order
+        sort_order_mapping = {"desc": -1, "asc": 1}
+        sort_order = sort_order_mapping.get(order, 1)
+        # Execute the query
+        image_tags_cursor = list(request.app.image_tags_collection\
+                                            .find(query).sort("creation_time", sort_order))
+        if image_type == '512*512_resolution':
+            # get only image resolution 512 * 512
+            temp_image_tags_cursor = []
+            for tag_data in image_tags_cursor:
+                if tag_data['image_source'] == 'extract_image':
+                    temp_image_tags_cursor.append(tag_data)
+                elif tag_data['image_source'] == 'generated_image':
+                    image = request.app.completed_jobs_collection.find_one({'task_output_file_dict.output_file_hash': tag_data['image_hash']})
+                    print(image, tag_data['image_hash'])
+                    if not image:
+                        continue
+                    
+                    if image['task_input_dict.image_width'] == 512 and image['task_input_dict.image_height'] == 512:
+                        print("512*512", image, tag_data['image_hash'])
+                        temp_image_tags_cursor.append(tag_data)
+                        
+            image_tags_cursor = temp_image_tags_cursor
+        # Process the results
+        image_info_list = []
+        for tag_data in image_tags_cursor:
+            if "image_hash" in tag_data and "user_who_created" in tag_data and "file_path" in tag_data:
+                image_tag = ImageTag(
+                    tag_id=int(tag_data["tag_id"]),
+                    file_path=tag_data["file_path"], 
+                    image_hash=str(tag_data["image_hash"]),
+                    tag_type=int(tag_data["tag_type"]),
+                    user_who_created=tag_data["user_who_created"],
+                    creation_time=tag_data.get("creation_time", None)
+                )
+                image_info_list.append(image_tag.model_dump())  # Convert to dictionary
+        # Return the list of images in a standard success response
+        return response_handler.create_success_response_v1(
+                                                           response_data={"images": image_info_list}, 
+                                                           http_status_code=200,
+                                                           )
+
+    except Exception as e:
+        # Log the exception details here, if necessary
+        return response_handler.create_error_response_v1(
+            error_code=ErrorCode.OTHER_ERROR, error_string="Internal Server Error", http_status_code=500
+        )
 
 @router.get("/tags/get-all-tagged-images", 
             tags=["tags"], 

--- a/orchestration/api/api_utils.py
+++ b/orchestration/api/api_utils.py
@@ -219,12 +219,15 @@ class AddJob(BaseModel):
     uuid: str
     creation_time: str
 
-def validate_date_format(date_str: str):
+def validate_date_format(date_str: Optional[str]):
     try:
-        # Attempt to parse the date string using dateutil.parser
-        parsed_date = parser.parse(date_str)
-        # If parsing succeeds, return the original date string
-        return date_str
+        if date_str is not None:
+            # Attempt to parse the date string using dateutil.parser
+            parsed_date = parser.parse(date_str)
+            # If parsing succeeds, return the original date string
+            return date_str
+        else:
+            return None
     except ValueError:
         # If parsing fails, return None
         return None
@@ -562,3 +565,17 @@ def get_ingress_video_path(bucket:str, video_metadata: VideoMetaData) -> str:
     
     return f'{path}.{video_metadata.file_type}'
     
+    
+def build_date_query(date_from: Optional[Union[str, datetime]] = None, 
+                     date_to: Optional[Union[str, datetime]] = None,  
+                     key: str = "creation_time") -> dict:
+    
+    date_range_query = {}
+    if date_from:
+        date_range_query["$gte"] = \
+            date_from.strftime('%Y-%m-%d') if isinstance(date_from, datetime) else date_from
+    if date_to:
+        date_range_query["$lte"] = \
+            date_to.strftime('%Y-%m-%d') if isinstance(date_to, datetime) else date_to
+    
+    return {key: date_range_query} if date_range_query else {}

--- a/scripts/model_training/elm_regression_classifier.py
+++ b/scripts/model_training/elm_regression_classifier.py
@@ -12,6 +12,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Train elm regression classifier model")
 
+    parser.add_argument('--minio-ip-addr', type=str, help='Minio ip address')
     parser.add_argument('--minio-access-key', type=str, help='Minio access key')
     parser.add_argument('--minio-secret-key', type=str, help='Minio secret key')
     parser.add_argument('--input-type', type=str, default="embedding")
@@ -35,7 +36,7 @@ if __name__ == '__main__':
     if args.tag_name != "all":
         try:
             print("Training model for tag: {}".format(args.tag_name))
-            train_classifier(minio_ip_addr=None,
+            train_classifier(minio_ip_addr=args.minio_ip_addr,
                              minio_access_key=args.minio_access_key,
                              minio_secret_key=args.minio_secret_key,
                              input_type=args.input_type,
@@ -59,7 +60,7 @@ if __name__ == '__main__':
         for tag_id, tag_name in zip(tag_id_list,tag_string_list):
             try:
                 print("Training model for tag: {}".format(tag_name))
-                train_classifier(minio_ip_addr=None,
+                train_classifier(minio_ip_addr=args.minio_ip_addr,
                                  minio_access_key=args.minio_access_key,
                                  minio_secret_key=args.minio_secret_key,
                                  input_type=args.input_type,

--- a/scripts/model_training/elm_regression_classifier.py
+++ b/scripts/model_training/elm_regression_classifier.py
@@ -15,6 +15,7 @@ def parse_arguments():
     parser.add_argument('--minio-access-key', type=str, help='Minio access key')
     parser.add_argument('--minio-secret-key', type=str, help='Minio secret key')
     parser.add_argument('--input-type', type=str, default="embedding")
+    parser.add_argument('--image-type', type=str, default="all") # Options ["all", "512"]
     parser.add_argument('--tag-name', type=str)
     parser.add_argument('--hidden-layer-neuron-count', type=int, default=3000)
     parser.add_argument('--pooling-strategy', type=int, default=0)
@@ -25,7 +26,12 @@ def parse_arguments():
 
 if __name__ == '__main__':
     args = parse_arguments()
-
+    
+    image_types = {
+        "all": "all_resolutions",
+        "512": "512*512_resolutions"
+    }
+    
     if args.tag_name != "all":
         try:
             print("Training model for tag: {}".format(args.tag_name))
@@ -33,6 +39,7 @@ if __name__ == '__main__':
                              minio_access_key=args.minio_access_key,
                              minio_secret_key=args.minio_secret_key,
                              input_type=args.input_type,
+                             image_type=image_types[args.image_type],
                              tag_name=args.tag_name,
                              hidden_layer_neuron_count=args.hidden_layer_neuron_count,
                              pooling_strategy=args.pooling_strategy,
@@ -56,6 +63,7 @@ if __name__ == '__main__':
                                  minio_access_key=args.minio_access_key,
                                  minio_secret_key=args.minio_secret_key,
                                  input_type=args.input_type,
+                                 image_type=image_types[args.image_type],
                                  tag_name=tag_name,
                                  tag_id=tag_id,
                                  hidden_layer_neuron_count=args.hidden_layer_neuron_count,

--- a/scripts/model_training/linear_regression_classifier.py
+++ b/scripts/model_training/linear_regression_classifier.py
@@ -12,6 +12,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Train linear regression classifier model")
 
+    parser.add_argument('--minio-ip-addr', type=str, help='Minio ip address')
     parser.add_argument('--minio-access-key', type=str, help='Minio access key')
     parser.add_argument('--minio-secret-key', type=str, help='Minio secret key')
     parser.add_argument('--input-type', type=str, default="embedding")
@@ -38,7 +39,7 @@ if __name__ == '__main__':
     if args.tag_name != "all":
         try:
             print("Training model for tag: {}".format(args.tag_name))
-            train_classifier(minio_ip_addr=None,
+            train_classifier(minio_ip_addr=args.minio_ip_addr,
                              minio_access_key=args.minio_access_key,
                              minio_secret_key=args.minio_secret_key,
                              input_type=args.input_type,
@@ -66,7 +67,7 @@ if __name__ == '__main__':
         for tag_id, tag_name in zip(tag_id_list, tag_string_list):
             try:
                 print("Training model for tag: {}".format(tag_name))
-                train_classifier(minio_ip_addr=None,
+                train_classifier(minio_ip_addr=args.minio_ip_addr,
                                  minio_access_key=args.minio_access_key,
                                  minio_secret_key=args.minio_secret_key,
                                  input_type=args.input_type,

--- a/scripts/model_training/linear_regression_classifier.py
+++ b/scripts/model_training/linear_regression_classifier.py
@@ -15,6 +15,7 @@ def parse_arguments():
     parser.add_argument('--minio-access-key', type=str, help='Minio access key')
     parser.add_argument('--minio-secret-key', type=str, help='Minio secret key')
     parser.add_argument('--input-type', type=str, default="embedding")
+    parser.add_argument('--image-type', type=str, default="all") # Options ["all", "512"]
     parser.add_argument('--tag-name', type=str)
     parser.add_argument('--pooling-strategy', type=int, default=0)
     parser.add_argument('--train-percent', type=float, default=0.9)
@@ -28,6 +29,12 @@ def parse_arguments():
 
 if __name__ == '__main__':
     args = parse_arguments()
+    
+    image_types = {
+        "all": "all_resolutions",
+        "512": "512*512_resolutions"
+    }
+    
     if args.tag_name != "all":
         try:
             print("Training model for tag: {}".format(args.tag_name))
@@ -35,6 +42,7 @@ if __name__ == '__main__':
                              minio_access_key=args.minio_access_key,
                              minio_secret_key=args.minio_secret_key,
                              input_type=args.input_type,
+                             image_type=image_types[args.image_type],
                              tag_name=args.tag_name,
                              pooling_strategy=args.pooling_strategy,
                              train_percent=args.train_percent,
@@ -62,6 +70,7 @@ if __name__ == '__main__':
                                  minio_access_key=args.minio_access_key,
                                  minio_secret_key=args.minio_secret_key,
                                  input_type=args.input_type,
+                                 image_type=image_types[args.image_type],
                                  tag_name=tag_name,
                                  tag_id=tag_id,
                                  pooling_strategy=args.pooling_strategy,

--- a/scripts/model_training/logistic_regression_classifier.py
+++ b/scripts/model_training/logistic_regression_classifier.py
@@ -15,6 +15,7 @@ def parse_arguments():
     parser.add_argument('--minio-access-key', type=str, help='Minio access key')
     parser.add_argument('--minio-secret-key', type=str, help='Minio secret key')
     parser.add_argument('--input-type', type=str, default="embedding")
+    parser.add_argument('--image-type', type=str, default="all") # Options ["all", "512"]
     parser.add_argument('--tag-name', type=str)
     parser.add_argument('--pooling-strategy', type=int, default=0)
     parser.add_argument('--train-percent', type=float, default=0.9)
@@ -28,6 +29,12 @@ def parse_arguments():
 
 if __name__ == '__main__':
     args = parse_arguments()
+    
+    image_types = {
+        "all": "all_resolutions",
+        "512": "512*512_resolutions"
+    }
+    
     if args.tag_name != "all":
         try:
             print("Training model for tag: {}".format(args.tag_name))
@@ -35,6 +42,7 @@ if __name__ == '__main__':
                              minio_access_key=args.minio_access_key,
                              minio_secret_key=args.minio_secret_key,
                              input_type=args.input_type,
+                             image_type=image_types[args.image_type],
                              tag_name=args.tag_name,
                              pooling_strategy=args.pooling_strategy,
                              train_percent=args.train_percent,
@@ -62,6 +70,7 @@ if __name__ == '__main__':
                                  minio_access_key=args.minio_access_key,
                                  minio_secret_key=args.minio_secret_key,
                                  input_type=args.input_type,
+                                 image_type=image_types[args.image_type],
                                  tag_name=tag_name,
                                  tag_id=tag_id,
                                  pooling_strategy=args.pooling_strategy,

--- a/scripts/model_training/logistic_regression_classifier.py
+++ b/scripts/model_training/logistic_regression_classifier.py
@@ -12,6 +12,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Train logistic regression classifier model")
 
+    parser.add_argument('--minio-ip-addr', type=str, help='Minio ip address')
     parser.add_argument('--minio-access-key', type=str, help='Minio access key')
     parser.add_argument('--minio-secret-key', type=str, help='Minio secret key')
     parser.add_argument('--input-type', type=str, default="embedding")
@@ -38,7 +39,7 @@ if __name__ == '__main__':
     if args.tag_name != "all":
         try:
             print("Training model for tag: {}".format(args.tag_name))
-            train_classifier(minio_ip_addr=None,
+            train_classifier(minio_ip_addr=args.minio_ip_addr,
                              minio_access_key=args.minio_access_key,
                              minio_secret_key=args.minio_secret_key,
                              input_type=args.input_type,
@@ -66,7 +67,7 @@ if __name__ == '__main__':
         for tag_id, tag_name in zip(tag_id_list, tag_string_list):
             try:
                 print("Training model for tag: {}".format(tag_name))
-                train_classifier(minio_ip_addr=None,
+                train_classifier(minio_ip_addr=args.minio_ip_addr,
                                  minio_access_key=args.minio_access_key,
                                  minio_secret_key=args.minio_secret_key,
                                  input_type=args.input_type,

--- a/training_worker/classifiers/scripts/elm_regression.py
+++ b/training_worker/classifiers/scripts/elm_regression.py
@@ -21,6 +21,7 @@ def train_classifier(minio_ip_addr=None,
                      minio_access_key=None,
                      minio_secret_key=None,
                      input_type="embedding",
+                     image_type="all_resolutions", # Options ["all_resolutions", "512*512_resolution"]
                      tag_name=None,
                      tag_id=None,
                      hidden_layer_neuron_count=3000,
@@ -55,7 +56,7 @@ def train_classifier(minio_ip_addr=None,
                                      input_type=input_type,
                                      pooling_strategy=pooling_strategy,
                                      train_percent=train_percent)
-    tag_loader.load_dataset()
+    tag_loader.load_dataset(image_type=image_type)
 
     # get dataset name
     dataset_name = tag_loader.dataset_name
@@ -69,13 +70,13 @@ def train_classifier(minio_ip_addr=None,
 
     # get final filename
     sequence = 0
-    filename = "{}-{:02}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type)
+    filename = "{}-{:02}-{}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type, image_type)
 
     # if exist, increment sequence
     while True:
-        filename = "{}-{:02}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type)
+        filename = "{}-{:02}-{}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type, image_type)
         exists = cmd.is_object_exists(tag_loader.minio_client, bucket_name,
-                                      os.path.join(output_path, filename + ".safetensors"))
+                                      os.path.join(output_path, filename + ".pth"))
         if not exists:
             break
 
@@ -108,7 +109,7 @@ def train_classifier(minio_ip_addr=None,
 
     # save model
     # Upload model to minio
-    model_name = "{}.safetensors".format(filename)
+    model_name = "{}.pth".format(filename)
     model_output_path = os.path.join(output_path, model_name)
     classifier_model.save_model(tag_loader.minio_client, bucket_name, model_output_path)
 

--- a/training_worker/classifiers/scripts/elm_regression.py
+++ b/training_worker/classifiers/scripts/elm_regression.py
@@ -1,3 +1,4 @@
+from re import I
 import sys
 import os
 from datetime import datetime
@@ -21,7 +22,7 @@ def train_classifier(minio_ip_addr=None,
                      minio_access_key=None,
                      minio_secret_key=None,
                      input_type="embedding",
-                     image_type="all_resolutions", # Options ["all_resolutions", "512*512_resolution"]
+                     image_type="all_resolutions", # Options ["all_resolutions", "512*512_resolutions"]
                      tag_name=None,
                      tag_id=None,
                      hidden_layer_neuron_count=3000,
@@ -186,3 +187,14 @@ def train_classifier(minio_ip_addr=None,
     # save model to mongodb if its input type is clip-h
     if(input_type==constants.KANDINSKY_CLIP):
         request.http_add_classifier_model(model_card)
+        
+        
+if __name__ == '__main__':
+    train_classifier('192.168.3.5:9000',
+                     'v048BpXpWrsVIHUfdAix',
+                     '4TFS20qkxVuX2HaC8ezAgG7GaDlVI1TqSPs0BKyu',
+                     tag_name='concept-architecture-scifi',
+                    #  image_type="512*512_resolutions",
+                     tag_id=55,
+                     input_type=constants.KANDINSKY_CLIP,
+                     )

--- a/training_worker/classifiers/scripts/elm_regression.py
+++ b/training_worker/classifiers/scripts/elm_regression.py
@@ -188,13 +188,3 @@ def train_classifier(minio_ip_addr=None,
     if(input_type==constants.KANDINSKY_CLIP):
         request.http_add_classifier_model(model_card)
         
-        
-if __name__ == '__main__':
-    train_classifier('192.168.3.5:9000',
-                     'v048BpXpWrsVIHUfdAix',
-                     '4TFS20qkxVuX2HaC8ezAgG7GaDlVI1TqSPs0BKyu',
-                     tag_name='concept-architecture-scifi',
-                    #  image_type="512*512_resolutions",
-                     tag_id=55,
-                     input_type=constants.KANDINSKY_CLIP,
-                     )

--- a/training_worker/classifiers/scripts/linear_regression.py
+++ b/training_worker/classifiers/scripts/linear_regression.py
@@ -181,13 +181,3 @@ def train_classifier(minio_ip_addr=None,
     # save model to mongodb if its input type is clip-h
     if(input_type==constants.KANDINSKY_CLIP):
         request.http_add_classifier_model(model_card)
-        
-if __name__ == '__main__':
-    train_classifier('192.168.3.5:9000',
-                     'v048BpXpWrsVIHUfdAix',
-                     '4TFS20qkxVuX2HaC8ezAgG7GaDlVI1TqSPs0BKyu',
-                     tag_name='concept-architecture-scifi',
-                    #  image_type="512*512_resolutions",
-                     tag_id=55,
-                     input_type=constants.KANDINSKY_CLIP,
-                     )

--- a/training_worker/classifiers/scripts/linear_regression.py
+++ b/training_worker/classifiers/scripts/linear_regression.py
@@ -39,6 +39,7 @@ def train_classifier(minio_ip_addr=None,
                      minio_access_key=None,
                      minio_secret_key=None,
                      input_type="embedding",
+                     image_type="all_resolutions", # Options ["all_resolutions", "512*512_resolutions"]
                      tag_name=None,
                      tag_id=None,
                      pooling_strategy=constants.AVERAGE_POOLING,
@@ -72,7 +73,7 @@ def train_classifier(minio_ip_addr=None,
                                      input_type=input_type,
                                      pooling_strategy=pooling_strategy,
                                      train_percent=train_percent)
-    tag_loader.load_dataset()
+    tag_loader.load_dataset(image_type=image_type)
 
     # get dataset name
     dataset_name = tag_loader.dataset_name
@@ -86,11 +87,11 @@ def train_classifier(minio_ip_addr=None,
 
     # get final filename
     sequence = 0
-    filename = "{}-{:02}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type)
+    filename = "{}-{:02}-{}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type, image_type)
 
     # if exist, increment sequence
     while True:
-        filename = "{}-{:02}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type)
+        filename = "{}-{:02}-{}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type, image_type)
         exists = cmd.is_object_exists(tag_loader.minio_client, bucket_name,
                                       os.path.join(output_path, filename + ".safetensors"))
         if not exists:
@@ -180,3 +181,13 @@ def train_classifier(minio_ip_addr=None,
     # save model to mongodb if its input type is clip-h
     if(input_type==constants.KANDINSKY_CLIP):
         request.http_add_classifier_model(model_card)
+        
+if __name__ == '__main__':
+    train_classifier('192.168.3.5:9000',
+                     'v048BpXpWrsVIHUfdAix',
+                     '4TFS20qkxVuX2HaC8ezAgG7GaDlVI1TqSPs0BKyu',
+                     tag_name='concept-architecture-scifi',
+                    #  image_type="512*512_resolutions",
+                     tag_id=55,
+                     input_type=constants.KANDINSKY_CLIP,
+                     )

--- a/training_worker/classifiers/scripts/logistic_regression.py
+++ b/training_worker/classifiers/scripts/logistic_regression.py
@@ -39,6 +39,7 @@ def train_classifier(minio_ip_addr=None,
                      minio_access_key=None,
                      minio_secret_key=None,
                      input_type="embedding",
+                     image_type="all_resolutions", # Options ["all_resolutions", "512*512_resolutions"]
                      tag_name=None,
                      tag_id=None,
                      pooling_strategy=constants.AVERAGE_POOLING,
@@ -72,7 +73,7 @@ def train_classifier(minio_ip_addr=None,
                                      input_type=input_type,
                                      pooling_strategy=pooling_strategy,
                                      train_percent=train_percent)
-    tag_loader.load_dataset()
+    tag_loader.load_dataset(image_type=image_type)
 
     # get dataset name
     dataset_name = tag_loader.dataset_name
@@ -86,11 +87,11 @@ def train_classifier(minio_ip_addr=None,
 
     # get final filename
     sequence = 0
-    filename = "{}-{:02}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type)
+    filename = "{}-{:02}-{}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type, image_type)
 
     # if exist, increment sequence
     while True:
-        filename = "{}-{:02}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type)
+        filename = "{}-{:02}-{}-{}-{}-{}-{}".format(date_now, sequence, tag_name, output_type, network_type, input_type, image_type)
         exists = cmd.is_object_exists(tag_loader.minio_client, bucket_name,
                                       os.path.join(output_path, filename + ".safetensors"))
         if not exists:
@@ -180,3 +181,13 @@ def train_classifier(minio_ip_addr=None,
     # save model to mongodb if its input type is clip-h
     if(input_type==constants.KANDINSKY_CLIP):
         request.http_add_classifier_model(model_card)
+                
+if __name__ == '__main__':
+    train_classifier('192.168.3.5:9000',
+                     'v048BpXpWrsVIHUfdAix',
+                     '4TFS20qkxVuX2HaC8ezAgG7GaDlVI1TqSPs0BKyu',
+                     tag_name='concept-architecture-scifi',
+                     image_type="512*512_resolutions",
+                     tag_id=55,
+                     input_type=constants.KANDINSKY_CLIP,
+                     )

--- a/training_worker/classifiers/scripts/logistic_regression.py
+++ b/training_worker/classifiers/scripts/logistic_regression.py
@@ -181,13 +181,3 @@ def train_classifier(minio_ip_addr=None,
     # save model to mongodb if its input type is clip-h
     if(input_type==constants.KANDINSKY_CLIP):
         request.http_add_classifier_model(model_card)
-                
-if __name__ == '__main__':
-    train_classifier('192.168.3.5:9000',
-                     'v048BpXpWrsVIHUfdAix',
-                     '4TFS20qkxVuX2HaC8ezAgG7GaDlVI1TqSPs0BKyu',
-                     tag_name='concept-architecture-scifi',
-                     image_type="512*512_resolutions",
-                     tag_id=55,
-                     input_type=constants.KANDINSKY_CLIP,
-                     )

--- a/utility/http/request.py
+++ b/utility/http/request.py
@@ -548,6 +548,35 @@ def http_get_tagged_images(tag_id):
 
     except Exception as e:
         print('request exception ', e)
+        
+
+def http_get_tagged_images_by_image_type(tag_id, image_type = "all_resolutions"):
+    url = SERVER_ADDRESS + "/tags/get-images-by-image-type/?tag_id={}&image_type={}".format(tag_id, image_type)
+    try:
+        response = requests.get(url)
+
+        if response.status_code == 200:
+            data_json = response.json()
+            return data_json["response"]["images"]
+
+    except Exception as e:
+        print('request exception ', e)
+        
+
+def http_get_tagged_images_by_resolution(tag_id, source = None):
+    if source is None:
+        url = SERVER_ADDRESS + "/tags/get-images-by-resolution/?tag_id={}".format(tag_id)
+    else:
+        url = SERVER_ADDRESS + "/tags/get-images-by-resolution/?tag_id={}&source={}".format(tag_id, source)
+    try:
+        response = requests.get(url)
+
+        if response.status_code == 200:
+            data_json = response.json()
+            return data_json["response"]["images"]
+
+    except Exception as e:
+        print('request exception ', e)
 
 
 def http_get_random_image_list(dataset, size):


### PR DESCRIPTION
### Add endpoint in api_tag
```
    /tags/get-images-by-image-type
    /tags/get-images-by-source
```

### update the classifier training scripts to train models for both 512*512 and separate models for all resolutions.