### PR TITLE
fix bug - endpoint for adding external image data

### DIFF
--- a/orchestration/api/api_external_images.py
+++ b/orchestration/api/api_external_images.py
@@ -12,7 +12,7 @@ from utility.minio import cmd
 import uuid
 from .api_clip import http_clip_server_get_cosine_similarity_list
 from .api_utils import get_next_external_dataset_seq_id, update_external_dataset_seq_id, get_minio_file_path, PrettyJSONResponse
-
+import asyncio
 
 
 router = APIRouter()
@@ -77,8 +77,11 @@ async def add_external_image_data(request: Request, image_data: ExternalImageDat
         image_data_dict.pop('_id', None)
 
         # update sequential
-        update_external_dataset_seq_id(request=request, bucket="external", dataset=image_data.dataset, seq_id=next_seq_id)
-
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(None, 
+                                            update_external_dataset_seq_id, 
+                                            request, "external", image_data.dataset, next_seq_id)
+        
         return api_response_handler.create_success_response_v1(
             response_data=image_data_dict,
             http_status_code=200
@@ -135,7 +138,10 @@ async def add_external_image_data_list(request: Request, image_data_list: List[E
                 # Insert the new image data into the collection
                 request.app.external_images_collection.insert_one(image_data_dict)
                 # update sequential id
-                update_external_dataset_seq_id(request=request, bucket="external", dataset=image_data.dataset, seq_id=next_seq_id)
+                loop = asyncio.get_event_loop()
+                result = await loop.run_in_executor(None, 
+                                                    update_external_dataset_seq_id, 
+                                                    request, "external", image_data.dataset, next_seq_id)
 
                 # add updated image_data into updated_image_data_list
                 updated_image_data_list.append(image_data_dict)


### PR DESCRIPTION
When update sequential id, it is not working well with workder because it seems that endpoint is asynchonously.