### PR TITLE
Uuid improvements

### DIFF
--- a/orchestration/api/api_all_images.py
+++ b/orchestration/api/api_all_images.py
@@ -9,7 +9,7 @@ from .api_utils import PrettyJSONResponse, StandardSuccessResponseV1, ApiRespons
 from .api_ranking import get_image_rank_use_count
 import os
 from .api_utils import find_or_create_next_folder_and_index
-from orchestration.api.mongo_schema.all_images_schemas import AllImagesResponse, ListAllImagesResponse
+from orchestration.api.mongo_schema.all_images_schemas import AllImagesHelpers, AllImagesResponse, ListAllImagesResponse
 import io
 from typing import List
 from PIL import Image
@@ -101,10 +101,7 @@ async def list_all_images(
 
         print(f"Number of images found: {len(images)}")
 
-        for image in images:
-            image.pop("_id", None)  # Remove the MongoDB ObjectId
-            if 'uuid' in image:
-                image['uuid'] = str(image['uuid'])  # Convert uuid to string
+        AllImagesHelpers.clean_image_list_for_api_response(images)
 
         return response_handler.create_success_response_v1(
             response_data={"images": images},
@@ -139,7 +136,7 @@ async def get_image_by_hash(request: Request, image_hash: str):
                 http_status_code=404
             )
         
-        image_data.pop('_id', None)
+        AllImagesHelpers.clean_image_for_api_response(image_data)
         # Return the found image data
         return api_response_handler.create_success_response_v1(
             response_data=image_data,

--- a/orchestration/api/api_utils.py
+++ b/orchestration/api/api_utils.py
@@ -781,3 +781,8 @@ def insert_into_all_images_for_completed(image_data, dataset_id, all_images_coll
     except Exception as e:
         print(f"Error inserting into all-images collection: {e}")
     
+
+def uuid64_number_to_string(uuid_number):
+    hex_string = uuid_number.to_bytes(8, 'big').hex()
+    return hex_string[0:4] + '-' + hex_string[4:8] + '-' + hex_string[8:12] + '-' + hex_string[12:16]
+

--- a/orchestration/api/mongo_schema/all_images_schemas.py
+++ b/orchestration/api/mongo_schema/all_images_schemas.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, Field, constr, validator
 from typing import List, Union, Optional
 import re
 from datetime import datetime
+from orchestration.api.api_utils import uuid64_number_to_string
 from orchestration.api.mongo_schemas import ImageMetadata
 
 class AllImagesResponse(BaseModel):
@@ -16,3 +17,17 @@ class AllImagesResponse(BaseModel):
 
 class ListAllImagesResponse(BaseModel):
     images: List[AllImagesResponse]
+
+class AllImagesHelpers():
+    @staticmethod
+    def clean_image_for_api_response(data: dict):
+        data.pop('_id', None)
+
+        if "uuid" in data:
+            if isinstance(data['uuid'], int):
+                    data['uuid'] = uuid64_number_to_string(data['uuid'])
+
+    @staticmethod
+    def clean_image_list_for_api_response(data_list: List[dict]):
+         for image_data in data_list:
+            AllImagesHelpers.clean_image_for_api_response(image_data)

--- a/orchestration/api/mongo_schema/extracts_schemas.py
+++ b/orchestration/api/mongo_schema/extracts_schemas.py
@@ -1,6 +1,8 @@
 from typing import List
 import uuid
 
+from orchestration.api.api_utils import uuid64_number_to_string
+
 class ExtractsHelpers():
     @staticmethod
     def clean_extract_for_api_response(data: dict):
@@ -8,6 +10,10 @@ class ExtractsHelpers():
         if "uuid" in data:
             if isinstance(data['uuid'], uuid.UUID):
                     data['uuid'] = str(data['uuid'])
+
+        if "image_uuid" in data:
+            if isinstance(data['image_uuid'], int):
+                    data['image_uuid'] = uuid64_number_to_string(data['image_uuid'])
 
     @staticmethod
     def clean_extract_list_for_api_response(data_list: List[dict]):


### PR DESCRIPTION
- A helper class to format the new 64 bit uuids was created. It returns a string like “0000-0000-0000-0000”, using big endian. It must be used alway for returning the new uuids in a consistent way.

- The extracts endpoints now return the “image_uuid” property using the correct format. The endpoints for external images and generated images will be fixed during the migration of the uuid datatype, to avoid doing some tests twice.

- A helper class for procesing the reponses of the all images endpoints was created. It simplifies the code and also prevents problems as the one we had where one endpoint was returning the uuids as a string and the other as a number.