### PR TITLE
API code improvements

### DIFF
--- a/orchestration/api/api_active_learning_policy.py
+++ b/orchestration/api/api_active_learning_policy.py
@@ -313,20 +313,14 @@ def delete_active_learning_policy(request: Request, policy_id: int ):
     response_handler = ApiResponseHandlerV1(request)
     
     try:
-        was_present = False
-
         # Check if the policy is being used by any queue pairs
         if request.app.active_learning_queue_pairs_collection.find_one({"active_learning_policy_id": policy_id}):
             return response_handler.create_error_response_v1(error_code=ErrorCode.INVALID_PARAMS, error_string="Cannot delete policy: It is being used by one or more queue pairs", http_status_code=400)
 
-        # Check if the policy exists and delete it
-        policy = request.app.active_learning_policies_collection.find_one({"active_learning_policy_id": policy_id})
-        if policy:
-            was_present = True
-            request.app.active_learning_policies_collection.delete_one({"active_learning_policy_id": policy_id})
-
-        # Return a success response indicating if the policy was deleted
-        return response_handler.create_success_delete_response_v1( was_present, 200)
+        # Delete the policy        
+        result = request.app.active_learning_policies_collection.delete_one({"active_learning_policy_id": policy_id})
+        # Return a standard response with wasPresent set to true if there was a deletion
+        return response_handler.create_success_delete_response_v1(result.deleted_count != 0)
     except Exception as e:
         # Handle any unexpected errors
         return response_handler.create_error_response(ErrorCode.OTHER_ERROR, "Internal server error", 500)    

--- a/orchestration/api/api_classifier_score.py
+++ b/orchestration/api/api_classifier_score.py
@@ -218,20 +218,14 @@ async def set_image_classifier_score(request: Request, classifier_score: Classif
                responses=ApiResponseHandlerV1.listErrors([422]))
 def delete_image_classifier_score_by_uuid(
     request: Request,
-    classifier_score_uuid: str):
+    classifier_score_uuid: str
+):
 
     api_response_handler = ApiResponseHandlerV1(request)
-    
-    query = {"uuid": classifier_score_uuid}
-    res = request.app.image_classifier_scores_collection.delete_one(query)
-    
-    was_present = res.deleted_count > 0
-    
-    # Use ApiResponseHandler to return the standardized response
-    return api_response_handler.create_success_delete_response_v1(
-        was_present,
-        http_status_code=200
-    )
+
+    res = request.app.image_classifier_scores_collection.delete_one({"uuid": classifier_score_uuid})
+    # Return a standard response with wasPresent set to true if there was a deletion
+    return api_response_handler.create_success_delete_response_v1(res.deleted_count != 0)
 
 
 @router.get("/classifier-score/list-by-scores", 
@@ -459,20 +453,8 @@ async def delete_image_classifier_score_by_uuid_and_classifier_id(
         "classifier_id": classifier_id  
     }
     res = request.app.image_classifier_scores_collection.delete_one(query)
-    
-    was_present = res.deleted_count > 0
-    
-    # Return the appropriate response based on whether an object was deleted
-    if was_present:
-        return api_response_handler.create_success_delete_response_v1(
-            True,
-            http_status_code=200
-        )
-    else:
-        return api_response_handler.create_success_delete_response_v1(
-            False,
-            http_status_code=200
-        )
+    # Return a standard response with wasPresent set to true if there was a deletion
+    return api_response_handler.create_success_delete_response_v1(res.deleted_count != 0)
 
 
 @router.get("/pseudotag-classifier-scores/list-image-by-scores", 

--- a/orchestration/api/api_utils.py
+++ b/orchestration/api/api_utils.py
@@ -373,8 +373,7 @@ class ApiResponseHandler:
 
      
 
-
-class StandardSuccessResponseV1(BaseModel, Generic[T]):
+class BaseStandardResponseV1(BaseModel):
     request_error_string: str = ""
     request_error_code: int = 0
     request_url: str
@@ -384,27 +383,25 @@ class StandardSuccessResponseV1(BaseModel, Generic[T]):
     request_time_start: datetime 
     request_time_finished: datetime
     request_response_code: int 
+
+class StandardSuccessResponseV1(BaseStandardResponseV1, Generic[T]):
     response: T 
 
 
-class StandardErrorResponseV1(BaseModel):
-    request_error_string: str = ""
-    request_error_code: int = -1
-    request_url: str
-    request_dictionary: dict 
-    request_method: str
-    request_complete_time: float
-    request_time_start: str 
-    request_time_finished: str
-    request_response_code: int 
+class StandardErrorResponseV1(BaseStandardResponseV1):
+    pass
 
      
 class ApiResponseHandlerV1:
-    def __init__(self, request: Request, body_data: Optional[Dict[str, Any]] = None):
+    def __init__(self, request: Request, body_data: Optional[Dict[str, Any]] = None, _created_with_helper=False):
         self.request = request
         self.url = str(request.url)
         self.start_time = datetime.now() 
         self.query_params = dict(request.query_params)
+
+        # At some point this must be used to throw errors if the instance is not created using a helper method.
+        if _created_with_helper is False:
+            pass
 
         # Parse the URL to extract and store the path
         parsed_url = urlparse(self.url)
@@ -423,13 +420,13 @@ class ApiResponseHandlerV1:
             body_string = body.decode('utf-8')
             body_dictionary = json.loads(body_string)
 
-        instance = ApiResponseHandlerV1(request, body_dictionary)
+        instance = ApiResponseHandlerV1(request, body_dictionary, _created_with_helper=True)
         return instance
     
     # In middlewares, this must be called instead of "createInstance", as "createInstance" may hang trying to get the request body.
     @staticmethod
     def createInstanceWithBody(request: Request, body_data: Dict[str, Any]):
-        instance = ApiResponseHandlerV1(request, body_data)
+        instance = ApiResponseHandlerV1(request, body_data, _created_with_helper=True)
         return instance
 
     
@@ -443,70 +440,68 @@ class ApiResponseHandlerV1:
             repsonse[err] = {"model": StandardErrorResponseV1}
         return repsonse
 
-    def create_success_response_v1(
+    def _create_metadata_and_process_headers(
         self,
-        response_data: dict,
-        http_status_code: int, 
-        headers: dict = {"Cache-Control": "no-store"},
+        http_status_code: int,
+        headers: dict,
     ):
-        # Validate the provided HTTP status code
-        if not 200 <= http_status_code < 300:
-            raise ValueError("Invalid HTTP status code for a success response. Must be between 200 and 299.")
+        if headers.get("Cache-Control") is None:
+            headers["Cache-Control"] = "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"
 
-        response_content = {
+        return {
             "request_error_string": '',
-            "request_error_code": 0, 
-            "request_url": self.url_path,
-            "request_dictionary": self.request_data,  # Or adjust how you access parameters
-            "request_method": self.request.method,
-            "request_complete_time": str(self._elapsed_time()),
-            "request_time_start": self.start_time.isoformat(),  
-            "request_time_finished": datetime.now().isoformat(), 
-            "request_response_code": http_status_code,
-            "response": response_data
-        }
-        return PrettyJSONResponse(status_code=http_status_code, content=response_content, headers=headers)
-
-
-    def create_success_delete_response_v1(
-            self, 
-            wasPresent: bool, 
-            http_status_code: int,
-            headers: dict = {"Cache-Control": "no-store"} ):
-        """Construct a success response for deletion operations."""
-        response_content = {
-            "request_error_string": '',
-            "request_error_code": 0, 
+            "request_error_code": 0,
             "request_url": self.url_path,
             "request_dictionary": self.request_data,
             "request_method": self.request.method,
             "request_complete_time": str(self._elapsed_time()),
             "request_time_start": self.start_time.isoformat(),
             "request_time_finished": datetime.now().isoformat(),
-            "request_response_code": http_status_code,
-            "response": {"wasPresent": wasPresent}
+            "request_response_code": http_status_code
         }
+
+    def create_success_response_v1(
+        self,
+        response_data: dict,
+        http_status_code: int, 
+        headers: dict = {},
+    ):
+        # Validate the provided HTTP status code
+        if not 200 <= http_status_code < 300:
+            raise ValueError("Invalid HTTP status code for a success response. Must be between 200 and 299.")
+        
+        response_content = self._create_metadata_and_process_headers(http_status_code, headers)
+        response_content["response"] = response_data
+
+        return PrettyJSONResponse(status_code=http_status_code, content=response_content, headers=headers)
+
+
+    def create_success_delete_response_v1(
+        self, 
+        wasPresent: bool, 
+        http_status_code: int = 200,
+        headers: dict = {}
+    ):
+        response_content = self._create_metadata_and_process_headers(http_status_code, headers)
+        response_content["response"] = {"wasPresent": wasPresent}
+
         return PrettyJSONResponse(status_code=http_status_code, content=response_content, headers=headers)
 
     def create_error_response_v1(
-            self,
-            error_code: ErrorCode,
-            error_string: str,
-            http_status_code: int,
-            headers: dict = {"Cache-Control": "no-store"},
-        ):
+        self,
+        error_code: ErrorCode,
+        error_string: str,
+        http_status_code: int,
+        headers: dict = {},
+    ):
+            # Validate the provided HTTP status code
+            if not 400 <= http_status_code < 599:
+                raise ValueError("Invalid HTTP status code for a success response. Must be between 400 and 599.")
             
-            response_content = {
-                "request_error_string": error_string,
-                "request_error_code": error_code.value,  # Using .name for the enum member name
-                "request_url": self.url_path,
-                "request_dictionary": self.request_data,  # Convert query params to a more usable dict format
-                "request_method": self.request.method,
-                "request_complete_time": str(self._elapsed_time()),
-                "request_time_start": self.start_time.isoformat(),
-                "request_time_finished": datetime.now().isoformat(),
-                "request_response_code": http_status_code
-            }
+            response_content = self._create_metadata_and_process_headers(http_status_code, headers)
+            response_content["request_error_string"] = error_string
+            response_content["request_error_code"] = error_code.value
+            
             return PrettyJSONResponse(status_code=http_status_code, content=response_content, headers=headers)
 
             


### PR DESCRIPTION
- Repeated code was removed from the code used for returning API responses.
- A problem that would cause the cache control header to be ignored when returning custom headers was fixed. Also, the cache control header now has a better value.
- Now the function for creating delete response does not request the response code, as it is always the same.
- The code for returning delete response in several parts of the API is now much shorter. There is a case of code that was 18 lines long and is now only 4 lines long.

This is only the start of various basic code improvements. For this PR there are still pending parts were the code has to be made shorter and other improvements that I’ll add later.