### PR TITLE
Formatted uuids for external images

### DIFF
--- a/orchestration/api/api_external_images.py
+++ b/orchestration/api/api_external_images.py
@@ -1,6 +1,7 @@
 
 from fastapi import APIRouter, Body, Request, HTTPException, Query, status
 from typing import Optional
+from orchestration.api.utils.uuid64 import Uuid64
 from utility.path import separate_bucket_and_file_path
 from .api_utils import ApiResponseHandlerV1, StandardSuccessResponseV1, ErrorCode, WasPresentResponse, DeletedCount, validate_date_format, TagListForImages, TagCountResponse, TagListForImagesV1, insert_into_all_images, generate_uuid,  check_image_usage, remove_from_additional_collections, delete_files_from_minio
 from .mongo_schemas import ExternalImageData, ImageHashRequest, ListExternalImageData, ListImageHashRequest, ExternalImageDataV1, ListExternalImageDataV1, ListDatasetV1, ListExternalImageDataWithSimilarityScore, Dataset, ListExternalImageDataV2, ListDataset
@@ -271,6 +272,9 @@ async def get_all_external_image_data_list(request: Request, dataset: str=None, 
 
         for image_data in image_data_list:
             image_data.pop('_id', None)  # Remove the auto-generated field
+            saved_uuid = image_data.get('image_uuid')
+            if saved_uuid and isinstance(saved_uuid, int):
+                image_data["image_uuid"] = Uuid64.from_mongo_value(saved_uuid).to_formatted_str()
 
         return api_response_handler.create_success_response_v1(
             response_data={"data": image_data_list},
@@ -310,6 +314,9 @@ async def get_all_external_image_data_list_v1(
 
         for image_data in image_data_list:
             image_data.pop('_id', None)  # Remove the auto-generated field
+            saved_uuid = image_data.get('image_uuid')
+            if saved_uuid and isinstance(saved_uuid, int):
+                image_data["image_uuid"] = Uuid64.from_mongo_value(saved_uuid).to_formatted_str()
 
         return api_response_handler.create_success_response_v1(
             response_data={"data": image_data_list},


### PR DESCRIPTION
Now the "/external-images/get-all-external-image-list" and "/external-images/get-all-external-image-list-v1" endpoints return the image uuids as formatted strings. The other endpoints were not updated to avoid any unexpected breaking change